### PR TITLE
Fix PHP execution vulnerabilities and secure database connection

### DIFF
--- a/LocalSettings.local.php
+++ b/LocalSettings.local.php
@@ -2,8 +2,8 @@
 
 #  Local configuration for MediaWiki
 
-ini_set( 'max_execution_time', 1000 );
-ini_set('memory_limit', '-1');
+ini_set( 'max_execution_time', 300 );
+ini_set( 'memory_limit', '1024M' );
 
 $wgEnableUploads = true;
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,7 +33,12 @@ wait_for_db() {
   [ -n "${MYSQL_HOST:-}" ] || return 0
   echo "Waiting for ${MYSQL_HOST} to accept connections..."
   i=0
-  until php -r "new PDO('mysql:host=${MYSQL_HOST};dbname=${MYSQL_DATABASE}','${MYSQL_USER}','${MYSQL_PASSWORD}');" 2>/dev/null; do
+  # Pass connection params through the environment (read with getenv) rather
+  # than interpolating them into the PHP source string. This keeps passwords
+  # containing quotes/backslashes from breaking the script or injecting code.
+  until MYSQL_HOST="$MYSQL_HOST" MYSQL_DATABASE="$MYSQL_DATABASE" \
+        MYSQL_USER="$MYSQL_USER" MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+        php -r 'new PDO("mysql:host=".getenv("MYSQL_HOST").";dbname=".getenv("MYSQL_DATABASE"), getenv("MYSQL_USER"), getenv("MYSQL_PASSWORD"));' 2>/dev/null; do
     i=$((i + 1))
     if [ "$i" -gt 60 ]; then
       echo "Timed out waiting for ${MYSQL_HOST}" >&2

--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -31,21 +31,30 @@ server {
     }
 
     # Serve .php files using fast-cgi
-    location ~ .php$ {
+    location ~ \.php$ {
+        # Refuse to pass requests for non-existent scripts to php-fpm. With
+        # cgi.fix_pathinfo=0 this also blocks path-info tricks (foo.jpg/x.php).
+        try_files $uri =404;
         include /etc/nginx/fastcgi_params;
         fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 
-    # Images — no PHP execution, required from MW 1.40+
-    location /w/images {
+    # Images — no PHP execution, required from MW 1.40+.
+    # ^~ stops nginx from falling through to the `~ \.php$` regex above, so an
+    # uploaded .php file in the images dir can never reach php-fpm.
+    location ^~ /w/images {
         add_header X-Content-Type-Options "nosniff";
-        location ~ \.(html?|shtml|phtml)$ {
+        # Never execute scripts uploaded into the images tree.
+        location ~* \.(php|php\d*|phtml|phar|cgi|pl|py)$ {
+            deny all;
+        }
+        location ~ \.(html?|shtml)$ {
             default_type text/plain;
         }
     }
-    location /w/images/deleted {
+    location ^~ /w/images/deleted {
         deny all;
     }
 


### PR DESCRIPTION
This pull request introduces several security and configuration improvements to the MediaWiki Docker setup. The main changes focus on securing PHP file handling in nginx, improving database connection handling in the entrypoint script, and tightening PHP resource limits.

**Security and configuration improvements:**

*nginx configuration hardening:*
- Updated the PHP file handler in `nginx-default.conf` to only match exact `.php` files and added `try_files $uri =404;` to prevent requests for non-existent scripts from reaching PHP-FPM, mitigating path traversal and path-info attacks.
- Strengthened the `/w/images` location block to explicitly deny execution of any uploaded scripts (e.g., `.php`, `.phtml`, `.phar`, `.cgi`, etc.) and prevent nginx from passing these files to PHP-FPM, further protecting against remote code execution via file uploads.

*Entrypoint script robustness:*
- Modified `docker-entrypoint.sh` to pass MySQL credentials via environment variables to PHP, preventing issues with special characters in passwords and reducing the risk of code injection.

*PHP resource limits:*
- Lowered the `max_execution_time` from 1000 to 300 seconds and set `memory_limit` to `1024M` (was unlimited) in `LocalSettings.local.php`, providing more reasonable resource constraints for PHP processes.